### PR TITLE
CircleCI integration

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -4,4 +4,5 @@ machine:
 
 test:
   override:
-    - flake8
+    - py.test tests/
+    - flake8 .

--- a/circle.yml
+++ b/circle.yml
@@ -5,6 +5,7 @@ machine:
 dependencies:
   override:
     - pip install -r requirements/local.txt
+    - cp playterminal/settings/secrets.dist.py playterminal/settings/secrets.py 
 
 test:
   override:

--- a/circle.yml
+++ b/circle.yml
@@ -2,6 +2,10 @@ machine:
   python:
     version: 3.4.2
 
+dependencies:
+  override:
+    - pip install -r requirements/local.txt
+
 test:
   override:
     - py.test tests/

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,7 @@
+machine:
+  python:
+    version: 3.4.2
+
+test:
+  override:
+    - flake8

--- a/playterminal/settings/base.py
+++ b/playterminal/settings/base.py
@@ -101,3 +101,10 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/1.8/howto/static-files/
 
 STATIC_URL = '/static/'
+
+# Try to get the secrets values from the environment
+secret_vars = ['SECRET_KEY', 'STEPIC_CLIENT_ID', 'STEPIC_CLIENT_SECRET']
+for var in secret_vars:
+    value = os.getenv(var)
+    if value:
+        globals()[var] = value


### PR DESCRIPTION
From now on, CircleCI is used to run the test suite and codebase checks: https://circleci.com/gh/rev112/playterminal 